### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Stories in Ready](https://badge.waffle.io/OpenDenton/Denton-Dashboard.png?label=ready&title=Ready)](https://waffle.io/OpenDenton/Denton-Dashboard)
 # Denton-Dashboard
 Static dashboard for open data in Denton.


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/OpenDenton/Denton-Dashboard

This was requested by a real person (user kyletaylored) on waffle.io, we're not trying to spam you.
